### PR TITLE
Update studying.md

### DIFF
--- a/src/studying.md
+++ b/src/studying.md
@@ -10,20 +10,19 @@ to start studying.
 Study in Anki is limited to the currently selected deck as well as any
 subdecks it contains.
 
-On the decks screen, your decks and subdecks will be displayed in a list. [New, Learn and Due (To Review)](getting-started.md#types-of-cards)
+On the decks screen, your decks and subdecks will be displayed in a list. [New, Learn, and Due (To Review)](getting-started.md#types-of-cards)
 cards for that day will be also displayed here.
 
 ![Decks screen](media/decks_screen.png)
 
 When you click on a deck, it will become the 'current deck', and Anki
-will change to the study screen. You can return to the deck list to
-change the currently selected deck at any time by clicking on “Decks” at
+will change to the study screen. You can return to the deck list at any time by clicking on “Decks” at
 the top of the main window. (You can also use the Study
 Deck action in the menu to select a new deck from the keyboard, or you
 can press the <kbd>s</kbd> key to study the currently selected deck.)
 
 You can click the gears button to the right of a deck to rename or
-delete a deck, change its [options](deck-options.md), or [export](exporting.md) it.
+delete the deck, change its [options](deck-options.md), or [export](exporting.md) it.
 
 ## Study Overview
 
@@ -51,7 +50,7 @@ When a card is shown, only the question is shown at first. After
 thinking about the answer, either click the **Show Answer** button, or
 press the spacebar. The answer will then be shown. It’s okay if it takes
 you a little while to recall the answer, but as a general rule if you
-can’t answer within about 10 seconds, it’s probably better to give up
+can’t answer within about 10 seconds, it’s probably better to move on
 and show the answer than keep struggling to remember.
 
 When the answer is shown, you should compare the answer you thought of
@@ -64,7 +63,7 @@ just showing it to you.
 
 When learning new cards, or when relearning cards that you have
 forgotten, Anki will show you the cards one or more times to help you
-memorize them. Each time is called a 'learning step'. By default there
+memorize them. Each time is called a 'learning step'. By default, there
 are two steps: 1 minute and 10 minutes. You can change the number of
 steps and the delays between them in the [deck options](deck-options.md#new-cards).
 


### PR DESCRIPTION
Fixed punctuation and articles, improved brevity of a sentence, added Oxford commas because it is used elsewhere in the document. Changed "give up" to "move on".

Dae, I noticed you use `""` at times and sometimes `''`. The US style is heavily used in the web but single inverted commas are easier to read and is recommended by Oxford's style guide. Is there a particular rule you are following while using inverted commas? 